### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/code/src/Attendee/Attendee.cs
+++ b/code/src/Attendee/Attendee.cs
@@ -9,7 +9,11 @@ namespace Attendees
     {
         public void WriteToDirectory(ZipArchiveEntry entry, string destDirectory)
         {
-            string destFileName = Path.Combine(destDirectory, entry.FullName);
+            string destFileName = Path.GetFullPath(Path.Combine(destDirectory, entry.FullName));
+            string fullDestDirPath = Path.GetFullPath(destDirectory + Path.DirectorySeparatorChar);
+            if (!destFileName.StartsWith(fullDestDirPath, StringComparison.Ordinal)) {
+                throw new InvalidOperationException("Entry is outside the target dir: " + destFileName);
+            }
             entry.ExtractToFile(destFileName);
         }
         


### PR DESCRIPTION
Potential fix for [https://github.com/SravandeepReddy2004/skills-secure-repository-supply-chain/security/code-scanning/1](https://github.com/SravandeepReddy2004/skills-secure-repository-supply-chain/security/code-scanning/1)

To fix the arbitrary file access ("Zip Slip") vulnerability in Attendee.cs, we must ensure that any file extracted from a zip entry is written only within the intended destination directory, regardless of the zip entry's path. The three recommended steps are:
1. Resolve the full path of the file to extract using `Path.GetFullPath(Path.Combine(destDirectory, entry.FullName))`.
2. Resolve the destination directory to a full path, using `Path.GetFullPath(destDirectory + Path.DirectorySeparatorChar)`.
3. Before extracting, validate that the fully resolved file path starts with the fully resolved destination directory path. If not, throw an exception to abort extraction.

These changes should be made in the `WriteToDirectory` method. No changes to class structure or functionality are needed, other than the path validation and the throwing of an exception for invalid archive entries.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
